### PR TITLE
This adds a script that can be run to create all the tables in our Cloud SQL MySQL Instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.sps</groupId>
-  <artifactId>portfolio</artifactId>
+  <artifactId>Starfish</artifactId>
   <version>1</version>
   <packaging>war</packaging>
 

--- a/src/main/sql/sql_tables.sql
+++ b/src/main/sql/sql_tables.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS labels ( 
+  title VARCHAR(255) PRIMARY KEY, 
+  type ENUM('School', 'Course', 'Other') NOT NULL 
+); 
+
+CREATE TABLE IF NOT EXISTS users ( 
+  id INT PRIMARY KEY AUTO_INCREMENT, 
+  display_picture VARCHAR(255), 
+  display_name VARCHAR(255), 
+  date_joined DATE, 
+  email VARCHAR(255) NOT NULL, 
+  points INT NOT NULL, 
+  school VARCHAR(255), 
+  FOREIGN KEY (`school`) 
+    REFERENCES `labels` (`title`) 
+    ON UPDATE RESTRICT ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS notes (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  author_id INT NOT NULL,
+  school VARCHAR(255) NOT NULL,
+  course VARCHAR(255) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  source_url VARCHAR(255) NOT NULL,
+  pdf_source VARCHAR(255),
+  date_created DATE NOT NULL,
+  num_downloads INT NOT NULL,
+  FOREIGN KEY (`author_id`)
+    REFERENCES `users` (`id`)
+    ON DELETE CASCADE,
+  FOREIGN KEY (`school`)
+    REFERENCES `labels` (`title`),
+  FOREIGN KEY (`course`)
+    REFERENCES `labels` (`title`),
+  CONSTRAINT pdf_or_source_url_not_null check (
+    `source_url` IS NOT NULL OR `pdf_source` IS NOT NULL
+  )
+);
+
+CREATE TABLE IF NOT EXISTS other_note_labels (
+  note_id INT NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  PRIMARY KEY (note_id, label),
+  FOREIGN KEY (`note_id`)
+    REFERENCES `notes` (`id`)
+    ON DELETE CASCADE,
+  FOREIGN KEY (`label`)
+    REFERENCES `labels` (`title`)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS favorite_notes (
+  user_id INT NOT NULL,
+  note_id INT NOT NULL,
+  PRIMARY KEY (user_id, note_id),
+  FOREIGN KEY (`user_id`)
+    REFERENCES `users` (`id`)
+    ON DELETE CASCADE,
+  FOREIGN KEY (`note_id`)
+    REFERENCES `notes` (`id`)
+    ON DELETE CASCADE
+);


### PR DESCRIPTION
The MySQL instance is up and running and to access it yourselves from the command line, follow the instructions in [this video]
(https://www.youtube.com/watch?v=25XIGXbw_GY).
## Entity Relationship Diagram
![image](https://user-images.githubusercontent.com/37886623/86944589-f78e6600-c115-11ea-8cd4-3b5bf5c24630.png)

A note about the size of the VARCHAR datatype in the schema - 255 is the largest number of characters than can be counted with an 8-bit number and is basically the 'max' length for a VARCHAR in most DB systems. In practice, even when set to the max number of characters, VARCHAR still only stores # of bytes + 1 for the text being stored, so it doesn't actually decrease performance. It seems like the only good reason to set a lower character max is for business logic reasons. Check out [this](https://stackoverflow.com/questions/1217466/is-there-a-good-reason-i-see-varchar255-used-so-often-as-opposed-to-another-l) SO post for reference.
