### PR TITLE
Fix image appearance on navbar

### DIFF
--- a/src/main/webapp/components/navbar.vue
+++ b/src/main/webapp/components/navbar.vue
@@ -73,6 +73,7 @@ module.exports = {
 .sticky {
   position: fixed;
   top: 0;
+  left: 0;
   width: 100%;
 }
 

--- a/src/main/webapp/components/navbar.vue
+++ b/src/main/webapp/components/navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="blue sticky nav-bar">
+  <nav class="navy-blue sticky nav-bar">
     <a href="index.html" class="bold" id="title">starfish</a>
     <img src="../assets/starfish.png" id="logo">
     <div id="action-items">
@@ -62,7 +62,7 @@ module.exports = {
   font-weight: bold;
 }
 
-.blue {
+.navy-blue {
   background-color: #004aad;
 }
 
@@ -71,7 +71,7 @@ module.exports = {
 }
 
 .sticky {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   width: 100%;

--- a/src/main/webapp/components/navbar.vue
+++ b/src/main/webapp/components/navbar.vue
@@ -112,6 +112,7 @@ module.exports = {
 }
 
 .dropdown {
+  height: 100%;
   overflow: hidden;
   padding: 0 10px 0 20px;
 }
@@ -125,6 +126,7 @@ module.exports = {
   height: 100%;
   margin: 0;
   outline: none;
+  width: 75px;
 }
 
 .dropdown .dropdown-btn:hover {

--- a/src/main/webapp/navbar.html
+++ b/src/main/webapp/navbar.html
@@ -4,8 +4,8 @@
     <script src="https://unpkg.com/vue"></script>
     <script src="https://unpkg.com/http-vue-loader"></script>
   </head>
-  <body style="margin: 0 auto">
-    <div id="my-app" style="height: 80px">
+  <body>
+    <div id="my-app">
       <navigation :user="user"></navigation>
     </div>
     <script>

--- a/src/main/webapp/navbar.html
+++ b/src/main/webapp/navbar.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <script src="https://unpkg.com/vue"></script>

--- a/src/main/webapp/navbar.html
+++ b/src/main/webapp/navbar.html
@@ -4,8 +4,8 @@
     <script src="https://unpkg.com/vue"></script>
     <script src="https://unpkg.com/http-vue-loader"></script>
   </head>
-  <body>
-    <div id="my-app">
+  <body style="margin: 0 auto">
+    <div id="my-app" style="height: 80px">
       <navigation :user="user"></navigation>
     </div>
     <script>


### PR DESCRIPTION
This fixes the appearance of the profile image on the navbar when `<!DOCTYPE html>` is added to any html file. 

![navbar](https://user-images.githubusercontent.com/39059181/87335384-35243200-c50e-11ea-8752-401ae3800b21.png)


Note: In order for the Vue directive `click-outside` to work completely, you will need to add
```css
html,
body {
  height: 100%;
}
```
into your stylesheet. 

Note: This only works when the vuetify stylesheet is also included.