### PR TITLE
This adds functionality to HandleNotesServlet to actually upload the posted note and its associated labels to the database

### DIFF
--- a/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
+++ b/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
@@ -25,7 +25,7 @@ import java.sql.ResultSet;
 import java.sql.Date;
 import java.util.Calendar;
 
-
+/** Servlet to handle note uploading and adding associated labels to the database */
 @WebServlet("/handle-notes")
 public class HandleNotesServlet extends HttpServlet {
 

--- a/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
+++ b/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
@@ -123,7 +123,6 @@ public class HandleNotesServlet extends HttpServlet {
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       response.getWriter().println("INTERNAL SERVER ERROR: " + ex);
     }    
-    response.sendRedirect("/");
   }
 
   /** Returns a blob key for the uploaded file, or null if the user didn't upload a file. */

--- a/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
+++ b/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
@@ -55,7 +55,7 @@ public class HandleNotesServlet extends HttpServlet {
     String title = request.getParameter("title");
     String school = request.getParameter("school").toLowerCase();
     String course = request.getParameter("course").toLowerCase();
-    String[] miscLabels = request.getParameter("miscLabels").split(",");
+    String[] miscLabels = request.getParameterValues("miscLabels");
 
     DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
 
@@ -93,9 +93,9 @@ public class HandleNotesServlet extends HttpServlet {
         noteStmt.setString(3, course);
         noteStmt.setString(4, title);
         if (sourceUrl == null) {
-          // If there was no sourceUrl, this is an uploaded pdf so
-          // set the sourceUrl to be the same as the pdfSource
-          noteStmt.setString(5, blobKey);
+          // If there was no sourceUrl, this is an uploaded pdf
+          // so set the source url to serve-notes path
+          noteStmt.setString(5, "/serve-notes?key=" + blobKey);
         } else {
           // If there is a sourceUrl on the request param, this is
           // a google doc set set the source url based on the passed param
@@ -105,7 +105,7 @@ public class HandleNotesServlet extends HttpServlet {
         // this will be null
         noteStmt.setString(6, blobKey);
         noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
-        noteStmt.setLong(8, 0);
+        noteStmt.setLong(8, 0); // num_downloads
         int rowsAffected = noteStmt.executeUpdate();
         if (rowsAffected == 1) {
           long noteId = 0;
@@ -158,6 +158,7 @@ public class HandleNotesServlet extends HttpServlet {
     for (Cookie cookie : cookies) {
       if (COOKIE_NAME.equals(cookie.getName())) {
         sessionId = cookie.getValue();
+        break;
       }
     }
 

--- a/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
+++ b/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
@@ -1,35 +1,41 @@
-package com.google.servlets;
+package com.google.starfish.servlets;
 
 import com.google.appengine.api.blobstore.BlobInfo;
 import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.blobstore.BlobInfoFactory;
-import com.google.appengine.api.blobstore.BlobInfo;
-import com.google.appengine.api.images.ServingUrlOptions;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;  
 import javax.servlet.http.Cookie;  
+import com.google.starfish.services.LabelService;
+import com.google.starfish.services.MiscNoteLabelService;
+import javax.sql.DataSource;
+import java.sql.Connection;  
+import java.sql.SQLException;  
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Date;
+import java.util.Calendar;
+
 
 @WebServlet("/handle-notes")
 public class HandleNotesServlet extends HttpServlet {
 
   private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
   private final String COOKIE_NAME = "SFCookie";
+  private LabelService labelService = new LabelService();
+  private MiscNoteLabelService miscNoteLabelService = new MiscNoteLabelService();
   
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
     if(!validateUser(request)) {
       response.setStatus(HttpServletResponse.SC_FORBIDDEN);
       return;
@@ -37,22 +43,87 @@ public class HandleNotesServlet extends HttpServlet {
 
     HttpSession activeSession = request.getSession(false);
     String userId = (String) activeSession.getAttribute("user_id");
-
     String blobKey = getUploadedFileBlobKey(request, "file");
-    if(blobKey == null) {
+    String sourceUrl = request.getParameter("sourceUrl");
+
+    // There must be some source, either a blob or url, for this note to be posted
+    if (blobKey == null && sourceUrl == null) {
       response.setStatus(HttpServletResponse.SC_NOT_ACCEPTABLE);
       return;
     }
-    String title = request.getParameter("title").toLowerCase();
+
+    String title = request.getParameter("title");
     String school = request.getParameter("school").toLowerCase();
     String course = request.getParameter("course").toLowerCase();
     String[] miscLabels = request.getParameter("miscLabels").split(",");
 
-    // TODO: Put labels into database
+    DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
 
-    // TODO: Put note into database
+    // Insert all labels before inserting note due to foreign key constraint
+    labelService.insertSchoolLabel(pool, school);
+    labelService.insertCourseLabel(pool, course);
+    for (String miscLabel : miscLabels) {
+      labelService.insertMiscLabel(pool, miscLabel.toLowerCase());
+    }
+    
+    try (Connection conn = pool.getConnection()) {
+      String stmt =
+          "INSERT INTO notes ( "
+              + "author_id,"
+              + "school,"
+              + "course,"
+              + "title,"
+              + "source_url,"
+              + "pdf_source,"
+              + "date_created,"
+              + "num_downloads ) "
+        + "VALUES ( "
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "? ); ";
 
-    response.setStatus(HttpServletResponse.SC_OK);
+      try (PreparedStatement noteStmt = conn.prepareStatement(stmt, new String[] {"id"})) {
+        noteStmt.setString(1, userId);
+        noteStmt.setString(2, school);
+        noteStmt.setString(3, course);
+        noteStmt.setString(4, title);
+        if (sourceUrl == null) {
+          // If there was no sourceUrl, this is an uploaded pdf so
+          // set the sourceUrl to be the same as the pdfSource
+          noteStmt.setString(5, blobKey);
+        } else {
+          // If there is a sourceUrl on the request param, this is
+          // a google doc set set the source url based on the passed param
+          noteStmt.setString(5, sourceUrl);
+        }
+        // The blob key is nullable on the notes table so if this is a google doc
+        // this will be null
+        noteStmt.setString(6, blobKey);
+        noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
+        noteStmt.setLong(8, 0);
+        int rowsAffected = noteStmt.executeUpdate();
+        if (rowsAffected == 1) {
+          long noteId = 0;
+          ResultSet rs = noteStmt.getGeneratedKeys();
+          if (rs.next()) {
+            noteId = rs.getLong(1);
+            // Associate misc labels to the newly added note
+            for (String miscLabel : miscLabels) {
+              miscNoteLabelService.insertMiscNoteLabel(pool, noteId, miscLabel);
+            }
+          } 
+        }
+      }
+    } catch (SQLException ex) {
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.getWriter().println("INTERNAL SERVER ERROR: " + ex);
+    }    
+    response.sendRedirect("/");
   }
 
   /** Returns a blob key for the uploaded file, or null if the user didn't upload a file. */
@@ -65,7 +136,7 @@ public class HandleNotesServlet extends HttpServlet {
       return null;
     }
 
-    // Form only contains a single file input, so get the first index
+    // Form only contains a single file input, so get the first index.
     BlobKey blobKey = blobKeys.get(0);
 
     // User submitted empty file
@@ -88,7 +159,6 @@ public class HandleNotesServlet extends HttpServlet {
     for (Cookie cookie : cookies) {
       if (COOKIE_NAME.equals(cookie.getName())) {
         sessionId = cookie.getValue();
-        break;
       }
     }
 

--- a/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
+++ b/src/main/java/com/google/starfish/servlets/HandleNotesServlet.java
@@ -85,27 +85,26 @@ public class HandleNotesServlet extends HttpServlet {
               + "?,"
               + "?,"
               + "?,"
-              + "? ); ";
+              + "0 ); ";
 
       try (PreparedStatement noteStmt = conn.prepareStatement(stmt, new String[] {"id"})) {
         noteStmt.setString(1, userId);
         noteStmt.setString(2, school);
         noteStmt.setString(3, course);
         noteStmt.setString(4, title);
-        if (sourceUrl == null) {
+        if (sourceUrl != null) {
+          // If there is a sourceUrl on the request param, this is
+          // a google doc set the source url based on the passed param
+          noteStmt.setString(5, sourceUrl);
+        } else {
           // If there was no sourceUrl, this is an uploaded pdf
           // so set the source url to serve-notes path
           noteStmt.setString(5, "/serve-notes?key=" + blobKey);
-        } else {
-          // If there is a sourceUrl on the request param, this is
-          // a google doc set set the source url based on the passed param
-          noteStmt.setString(5, sourceUrl);
         }
         // The blob key is nullable on the notes table so if this is a google doc
         // this will be null
         noteStmt.setString(6, blobKey);
         noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
-        noteStmt.setLong(8, 0); // num_downloads
         int rowsAffected = noteStmt.executeUpdate();
         if (rowsAffected == 1) {
           long noteId = 0;


### PR DESCRIPTION
# Ingest Flow
- Validate that the user is logged in and get their `userId` (must be logged in to upload a note)
- Check if there is a `sourceUrl` passed as a param or a valid `blobKey` for an uploaded file: if there isn't, do nothing and return
- Get all remaining params that describe the note
- Get all labels (`school`, `course`, `misc`)
- Insert all labels into the LABELS table because of FK restraint on the NOTES table
- Insert the new Note into the NOTES table and get the newly posted `noteId`
- Associate the new Note with each misc label by inserting a new row into the MISC_NOTE_LABELS table for every misc label

## Note About null checks on `blobKey` and `sourceUrl`
On the NOTES table, `sourceUrl` is not null and `blobKey` is nullable. The original design decision made was to make it so either of these columns could be `null`, but both couldn't be `null` at the same time. Unfortunately, this is [not possible to do in MySQL](https://stackoverflow.com/questions/33611597/how-define-column-a-or-column-b-not-null) (Although it is possible in SQLServer). 
Realizing this, the alternative usage considers the two note uploading cases: "Uploading" a Google Doc, and uploading a PDF.

### Uploading a Google Doc
When uploading a Google Doc, the `sourceUrl` must be passed as a query param and must be not null. In this case however, there will be no blob key (because there is no associated PDF), so in the DB, the `pdfSource` will be `null` (which is fine because pdfSource is nullable). This nicely sets up the possibility for future functionality when a Google Doc could be transformed into a PDF on the platform and we'd want to keep the Google Doc url in `sourceUrl` and the `blobKey` in `pdfSource`.

### Uploading a PDF
When uploading a PDF, the servlet will get a `blobKey `itself by handling the uploading to Blobstore. The only "source" for this PDF is Blobstore, so it makes sense to keep the `blobKey` as the `sourceUrl` in addition to keeping the `pdfSource` the `blobKey` as well.