### PR TITLE
This adds methods to the UserService class to track increases in points based on an event

### DIFF
--- a/src/main/java/com/google/starfish/services/UserService.java
+++ b/src/main/java/com/google/starfish/services/UserService.java
@@ -3,15 +3,86 @@ package com.google.starfish.services;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;  
-import java.sql.ResultSet;  
 import javax.sql.DataSource;
+
+enum Event {
+  FAVORITE, DOWNLOAD
+}
 
 /**
  * Service class for Users Table 
  */
 public class UserService extends TableService {
 
+  private String USERS = Table.USERS.getSqlTable();
+
+  // Points modifiers for different events
+  private final long FAVORITE_POINTS_MODIFIER = 3;
+  private final long DOWNLOAD_POINTS_MODIFIER = 5;
+
   public UserService() {
     super(Table.USERS);
+  }
+
+  /** Increase user points when a user's note gets favorited */
+  public boolean increasePointsOnFavorite(DataSource pool, String userId) {
+    return increasePoints(pool, userId, Event.FAVORITE);
+  }
+
+  /** Increase user points when a user's note gets downloaded */
+  public boolean increasePointsOnDownload(DataSource pool, String userId) {
+    return increasePoints(pool, userId, Event.DOWNLOAD);
+  }
+
+  /** Variably increase user points based on event */
+  private boolean increasePoints(DataSource pool, String userId, Event event) {
+    if (userId == null) return false;
+    long pointsModifier = getPointsModifier(event);
+    try (Connection conn = pool.getConnection()) {
+      try {
+        conn.setAutoCommit(false);
+        String stmt =
+            "UPDATE " + USERS + " "
+                + "SET points=points+? "
+          + "WHERE id=?;";
+        try (PreparedStatement updateStmt = conn.prepareStatement(stmt)) {
+          updateStmt.setLong(1, pointsModifier);
+          updateStmt.setString(2, userId);
+          boolean updated = updateStmt.execute();
+          conn.commit();
+          return updated;
+        }
+      } catch(SQLException ex) {
+        if (conn != null) {
+          try {
+            System.err.print("Transaction is being rolled back.");
+            conn.rollback();
+          } catch (SQLException excep) {
+            System.err.print(excep);
+            return false;
+          }
+        }
+        return false;
+      }
+    } catch (SQLException ex) {
+      System.err.print(ex);
+      return false;
+    }
+  }
+
+  /** Gets the points modifier based on the event */
+  private long getPointsModifier(Event event) {
+    long pointsModifier = 0;
+    switch (event) {
+      case FAVORITE:
+        pointsModifier = FAVORITE_POINTS_MODIFIER;
+        break;
+      case DOWNLOAD:
+        pointsModifier = DOWNLOAD_POINTS_MODIFIER;
+        break;
+      default:
+        pointsModifier = FAVORITE_POINTS_MODIFIER;
+    }
+    return pointsModifier;
   }
 }

--- a/src/main/java/com/google/starfish/services/UserService.java
+++ b/src/main/java/com/google/starfish/services/UserService.java
@@ -37,7 +37,6 @@ public class UserService extends TableService {
   /** Variably increase user points based on event */
   private boolean increasePoints(DataSource pool, String userId, Event event) {
     if (userId == null) return false;
-    long pointsModifier = getPointsModifier(event);
     try (Connection conn = pool.getConnection()) {
       try {
         conn.setAutoCommit(false);
@@ -46,6 +45,7 @@ public class UserService extends TableService {
                 + "SET points=points+? "
           + "WHERE id=?;";
         try (PreparedStatement updateStmt = conn.prepareStatement(stmt)) {
+          long pointsModifier = getPointsModifier(event);
           updateStmt.setLong(1, pointsModifier);
           updateStmt.setString(2, userId);
           boolean updated = updateStmt.execute();


### PR DESCRIPTION
# Description
Depending on the event occurred, a user's points will either need to increase or decrease. Events are kept in an enum and it is easy to add new events to increase/decrease points. The steps one would have to take to add a new event would be:
1. Add event to enum
2. Add final variable constant to indicate the point modifier for that event
3. Add a case to the switch statement in `getPointsModifier`
4. Create a new method which calls `increasePoints` with the new event

For now, the only two events are Favorite and Download: the Download event is given more weight than the Favorite event but the values of the points modifiers can easily be changed if needed.

# Testing
## Before and after calling`increasePointsOnFavorite` and `increasePointsOnDownload` for user "118020203765270061430"
![image](https://user-images.githubusercontent.com/37886623/88079024-24497100-cb4b-11ea-8715-37a2e8a3194a.png)

