### PR TITLE
Integrate chrome extension with webapp servlets

### DIFF
--- a/chrome-extension/popup.css
+++ b/chrome-extension/popup.css
@@ -27,6 +27,7 @@ nav span {
 
 nav img {
   height: 65%;
+  margin: 0 0 5px 5px;
 }
 
 section {

--- a/chrome-extension/popup.css
+++ b/chrome-extension/popup.css
@@ -3,7 +3,7 @@ body {
   font-size: 1rem;
   margin: 0;
   position: relative;
-  width: 325px;
+  width: 300px;
 }
 
 .bold {

--- a/chrome-extension/popup.css
+++ b/chrome-extension/popup.css
@@ -61,6 +61,7 @@ button:hover {
 
 input {
   font-size: inherit;
+  margin: 5px 0;
 }
 
 #user-info {

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -19,7 +19,12 @@
       <section id="gnote-form">
         <span class="bold heading">gNote</span>
         <div class="card" id="gnote-card">
-          <span>Title: <input type="text" id="doc-name-input"></span>
+          <span>Title:</span>
+          <input type="text" id="doc-name-input">
+          <span>School:</span>
+          <input type="text" id="school-input" value="Unaffiliated">
+          <span>Course:</span>
+          <input type="text" id="course-input" value="Unaffiliated">
           <span><input type="checkbox"> Share Publicly</span>
           <button id="generate-note-btn" disabled>Generate</button>
           <div id="loading">

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -14,7 +14,7 @@
         <span class="bold heading">User</span>
         <div class="card">
           <span id="email"></span>
-        </card>
+        </div>
       </section>
       <section id="gnote-form">
         <span class="bold heading">gNote</span>

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -32,7 +32,7 @@
         </div>
       </section>
       <section id="footer">
-        <button class="bold link">Open Browser</button>
+        <button class="bold link" id="browser-btn">Open Browser</button>
         <button class="bold link" id="login-btn">Login</button>
         <button class="bold link" id="logout-btn">Logout</button>
       </section>

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -22,10 +22,9 @@
           <span>Title:</span>
           <input type="text" id="doc-name-input">
           <span>School:</span>
-          <input type="text" id="school-input" value="Unaffiliated">
+          <input type="text" id="school-input">
           <span>Course:</span>
-          <input type="text" id="course-input" value="Unaffiliated">
-          <span><input type="checkbox"> Share Publicly</span>
+          <input type="text" id="course-input">
           <button id="generate-note-btn" disabled>Generate</button>
           <div id="loading">
             <img src="images/loading.gif">

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -256,15 +256,16 @@ function logoutUserOnWebapp() {
 function setAccountInfo() {
   if(loggedIn) {
     gapi.client.request({
-      path: USER_INFO_URL + accessToken
-    }).then(response => {
-      let userInfo = JSON.parse(response.body);
-      document.getElementById('logout-btn').style.display = 'inline';
-      document.getElementById('email').textContent = userInfo.email;
-      document.getElementById('user-info').style.display = 'block';
-      document.getElementById('login-btn').style.display = 'none';
-      document.getElementById('generate-note-btn').disabled = false;
-    });
+      path: WEBAPP_URL + '/user-registration',
+      method: 'GET'
+    }).then(response => response.json())
+      .then(userInfo => {
+        document.getElementById('logout-btn').style.display = 'inline';
+        document.getElementById('email').textContent = userInfo.email;
+        document.getElementById('user-info').style.display = 'block';
+        document.getElementById('login-btn').style.display = 'none';
+        document.getElementById('generate-note-btn').disabled = false;
+      });
   } else {
     document.getElementById('logout-btn').style.display = 'none';
     document.getElementById('email').textContent = '';

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -103,7 +103,6 @@ function getTokenEndpoint(url) {
 
 /** Sends request to webapp's user registration servlet. */
 function registerUserOnWebapp(idToken) {
-  // TODO: Change URL to deployed website URL
   fetch(WEBAPP_URL + '/user-registration?idToken=' + idToken, {
     method: 'POST'
   }).then(() => {
@@ -124,28 +123,48 @@ function getDate() {
  * with the newly created Google Doc.
  */
 function generateNote() {
-  let loadingIcon = document.getElementById('loading');
-  loadingIcon.style.display = 'flex';
-  let docName = document.getElementById('doc-name-input').value.trim();
-  if(docName === '') {
-    docName = 'gNote ' + getDate();
-  }
+  postNoteToDatabase();
+  // let loadingIcon = document.getElementById('loading');
+  // loadingIcon.style.display = 'flex';
+  // let docName = document.getElementById('doc-name-input').value.trim();
+  // if(docName === '') {
+  //   docName = 'gNote ' + getDate();
+  // }
 
-  gapi.client.request({
-    path: COPY_FILE_URL,
+  // gapi.client.request({
+  //   path: COPY_FILE_URL,
+  //   method: 'POST',
+  //   params: {fileId: NOTES_TEMPLATE_DOC_ID},
+  //   body: {
+  //     name: docName,
+  //   }
+  // }).then(response => {
+  //   // TODO: Make POST request to upload notes servlet
+  //   const gNoteURL = GOOGLE_DOC_URL + response.result.id;
+  //   loadingIcon.style.display = 'none';
+  //   chrome.tabs.create({ url: gNoteURL });
+  // }).catch(error => {
+  //   loadingIcon.style.display = 'none';
+  //   console.log('Error:', error);
+  // })
+}
+
+/**
+ * Makes a request to the webapp's upload gnote servlet to add 
+ * the note to the database.
+ */
+function postNoteToDatabase() {
+  let payload = {
+    title: 'Title',
+    school: 'NYU',
+    course: 'CS4410',
+    sourceUrl: 'sourceurl',
+    pdfSource: 'pdfSource'
+  }
+  let data = new URLSearchParams(payload);
+  fetch(WEBAPP_URL + '/upload-gnote', {
     method: 'POST',
-    params: {fileId: NOTES_TEMPLATE_DOC_ID},
-    body: {
-      name: docName,
-    }
-  }).then(response => {
-    // TODO: Make POST request to upload notes servlet
-    const gNoteURL = GOOGLE_DOC_URL + response.result.id;
-    loadingIcon.style.display = 'none';
-    chrome.tabs.create({ url: gNoteURL });
-  }).catch(error => {
-    loadingIcon.style.display = 'none';
-    console.log('Error:', error);
+    body: data
   })
 }
 

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -124,7 +124,7 @@ function getDate() {
  */
 function setLoadingIcon(show) {
   const loadingIcon = document.getElementById('loading');
-  loadingIcon.style.display = (show ? 'flex' : 'none');
+  loadingIcon.style.display = show ? 'flex' : 'none';
 }
 
 /**

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -134,10 +134,7 @@ function setLoadingIcon(show) {
  */
 function generateNote() {
   setLoadingIcon(true);
-  let docName = document.getElementById('doc-name-input').value.trim();
-  if(docName === '') {
-    docName = 'gNote ' + getDate();
-  }
+  const [docName, school, course] = retrieveParams();
 
   gapi.client.request({
     path: COPY_FILE_URL,
@@ -149,22 +146,33 @@ function generateNote() {
   }).then(response => {
     const docId = response.result.id;
     const gNoteUrl = GOOGLE_DOC_URL + docId;
-    compileNoteData(docName, docId, gNoteUrl)
+    compileNoteData(docName, docId, gNoteUrl, school, course);
   }).catch(error => {
     setLoadingIcon(false);
     console.log('Error:', error);
   })
 }
 
+/** Retrieves input values and sets them if they are blank */
+function retrieveParams() {
+  let docName = document.getElementById('doc-name-input').value.trim();
+  if(docName === '') docName = 'gNote ' + getDate();
+  let school = document.getElementById('school-input').value.trim();
+  if(school === '') school = 'Unaffiliated';
+  let course = document.getElementById('course-input').value.trim();
+  if(course === '') course = 'Unaffiliated';
+  return [docName, school, course];
+}
+
 /** Puts together the URL search params for posting the note */
-async function compileNoteData(title, docId, docUrl) {
+async function compileNoteData(title, docId, docUrl, school, course) {
   getPDFLink(docId)
     .then(response => {
       const pdfSource = response.result.exportLinks['application/pdf'];
       const payload = {
         title: title,
-        school: 'Unaffiliated',
-        course: 'Unaffiliated',
+        school: school,
+        course: course,
         sourceUrl: docUrl,
         pdfSource: pdfSource
       }

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -178,11 +178,31 @@ async function compileNoteData(title, docId, docUrl, school, course) {
       }
       const noteData = new URLSearchParams(payload);
       postNoteToDatabase(noteData)
-        .then(() => {
-          setLoadingIcon(false);
-          chrome.tabs.create({ url: docUrl })
-        });
+        .then(updateGNoteTemplate(docId, docUrl));
     })
+}
+
+/** Replaces [DATE] fields in template with the current date */
+function updateGNoteTemplate(docId, docUrl) {
+  var updateObject = {
+      documentId: docId,
+      resource: {
+        requests: [{
+          replaceAllText: {
+            replaceText: getDate(),
+            containsText: {
+              text: "[DATE]",
+              matchCase: true
+            }
+          },
+        }],
+      },
+    };
+    gapi.client.docs.documents.batchUpdate(updateObject)
+      .then(() => { 
+        setLoadingIcon(false);
+        chrome.tabs.create({ url: docUrl })
+      });
 }
 
 /** Retrieves PDF export link of Google Doc */

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -255,10 +255,8 @@ function logoutUserOnWebapp() {
  */
 function setAccountInfo() {
   if(loggedIn) {
-    gapi.client.request({
-      path: WEBAPP_URL + '/user-registration',
-      method: 'GET'
-    }).then(response => response.json())
+    fetch(WEBAPP_URL + '/user-registration')
+      .then(response => response.json())
       .then(userInfo => {
         document.getElementById('logout-btn').style.display = 'inline';
         document.getElementById('email').textContent = userInfo.email;

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -154,12 +154,12 @@ function generateNote() {
 
 /** Retrieves input values and sets them if they are blank */
 function retrieveParams() {
-  let docName = document.getElementById('doc-name-input').value.trim();
-  if(docName === '') docName = 'gNote ' + getDate();
-  let school = document.getElementById('school-input').value.trim();
-  if(school === '') school = 'Unaffiliated';
-  let course = document.getElementById('course-input').value.trim();
-  if(course === '') course = 'Unaffiliated';
+  const docName = document.getElementById('doc-name-input').value.trim() ||
+      'gNote ' + getDate();
+  const school = document.getElementById('school-input').value.trim() ||
+      'Unaffiliated';
+  const course = document.getElementById('course-input').value.trim() ||
+      'Unaffiliated';
   return [docName, school, course];
 }
 
@@ -200,9 +200,9 @@ function updateGNoteTemplate(docId, docUrl) {
   gapi.client.docs.documents.batchUpdate(updateObject)
     .then(() => addGlobalPermissions(docId))
     .then(() => {
-      setLoadingIcon(false);
       chrome.tabs.create({ url: docUrl });
-    });
+    })
+    .finally(setLoadingIcon(false));
 }
 
 /** Add global permissions to Google Doc so anyone can view it */

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -29,7 +29,6 @@ const DISCOVERY_DOCS = [
 
 let loggedIn = false;
 let accessToken = '';
-let idToken = '';
 
 /**
  * Gets the script for Google APIs client library for browser-side
@@ -86,11 +85,8 @@ function login() {
           '&client_secret=' + CLIENT_SECRET;
       getTokenEndpoint(newUrl)
         .then(tokenInfo => {
-          idToken = tokenInfo.id_token;
           accessToken = tokenInfo.access_token;
-          gapi.auth.setToken({ access_token: accessToken });
-          loggedIn = true;
-          setAccountInfo();
+          registerUserOnDatabase(tokenInfo.id_token);
         })
     }
   })
@@ -101,6 +97,18 @@ function getTokenEndpoint(url) {
   return fetch(url, {
     method: 'POST'
   }).then(response => response.json());
+}
+
+/** Sends request to webapp's user registration servlet. */
+function registerUserOnDatabase(idToken) {
+  // TODO: Change URL to deployed website URL
+  fetch('https://8080-cacf7a03-5e11-4b90-94f2-e81659d32917.us-east1.cloudshell.dev/user-registration?idToken=' + idToken, {
+    method: 'POST'
+  }).then(() => {
+    gapi.auth.setToken({ access_token: accessToken });
+    loggedIn = true;
+    setAccountInfo();
+  });
 }
 
 /** Returns formatted string of today's date. */
@@ -161,7 +169,7 @@ function logout() {
 function setAccountInfo() {
   if(loggedIn) {
     gapi.client.request({
-      path: USER_INFO_URL + accesToken
+      path: USER_INFO_URL + accessToken
     }).then(response => {
       let userInfo = JSON.parse(response.body);
       document.getElementById('logout-btn').style.display = 'inline';

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -76,7 +76,6 @@ function login() {
     if(chrome.runtime.lastError) {
       return;
     } else {
-      // TODO: Make a POST request to user sign in servlet
       const response = redirectedTo.split('?code=', 2)[1];
       const code = response.split('&scope', 1)[0];
       const newUrl =
@@ -151,7 +150,7 @@ function generateNote() {
   }).catch(error => {
     setLoadingIcon(false);
     console.log('Error:', error);
-  })
+  });
 }
 
 /** Retrieves input values and sets them if they are blank */
@@ -176,11 +175,11 @@ async function compileNoteData(title, docId, docUrl, school, course) {
         course: course,
         sourceUrl: docUrl,
         pdfSource: pdfSource
-      }
+      };
       const noteData = new URLSearchParams(payload);
       postNoteToDatabase(noteData)
         .then(updateGNoteTemplate(docId, docUrl));
-    })
+    });
 }
 
 /** Replaces [DATE] fields in template with the current date */
@@ -202,7 +201,7 @@ function updateGNoteTemplate(docId, docUrl) {
     gapi.client.docs.documents.batchUpdate(updateObject)
       .then(() => { 
         setLoadingIcon(false);
-        chrome.tabs.create({ url: docUrl })
+        chrome.tabs.create({ url: docUrl });
       });
 }
 
@@ -222,7 +221,7 @@ function postNoteToDatabase(noteData) {
   return fetch(WEBAPP_URL + '/upload-gnote', {
     method: 'POST',
     body: noteData
-  })
+  });
 }
 
 /**
@@ -246,7 +245,7 @@ function logoutUserOnWebapp() {
     gapi.auth.setToken({ access_token: accessToken });
     loggedIn = false;
     setAccountInfo();
-  })
+  });
 }
 
 /**

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -207,7 +207,7 @@ function updateGNoteTemplate(docId, docUrl) {
 }
 
 /** Add global permissions to Google Doc so anyone can view it */
-function addGlobalPermissions() {
+function addGlobalPermissions(docId) {
   return gapi.client.request({
     path: FILE_PERMISSIONS_URL,
     method: 'POST',

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -44,6 +44,7 @@ window.onload = function() {
   document.getElementById('generate-note-btn').onclick = generateNote;
   document.getElementById('logout-btn').onclick = logout;
   document.getElementById('login-btn').onclick = login;
+  document.getElementById('browser-btn').onclick = openBrowser;
   document.getElementById('doc-name-input').value = 'gNote ' + getDate();
 }
 
@@ -272,4 +273,8 @@ function setAccountInfo() {
     document.getElementById('login-btn').style.display = 'inline';
     document.getElementById('generate-note-btn').disabled = true;
   }
+}
+
+function openBrowser() {
+  chrome.tabs.create({ url: WEBAPP_URL });
 }

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -138,10 +138,11 @@ function generateNote() {
       name: docName,
     }
   }).then(response => {
-    const gNoteURL = GOOGLE_DOC_URL + response.result.id;
-    compileNoteData(docName, gNoteUrl);
+    const docId = response.result.id;
+    const gNoteUrl = GOOGLE_DOC_URL + docId;
+    compileNoteData(docName, docId, gNoteUrl);
     loadingIcon.style.display = 'none';
-    chrome.tabs.create({ url: gNoteURL });
+    chrome.tabs.create({ url: gNoteUrl });
   }).catch(error => {
     loadingIcon.style.display = 'none';
     console.log('Error:', error);
@@ -149,8 +150,8 @@ function generateNote() {
 }
 
 /** Puts together the URL search params for posting the note */
-async function compileNoteData(title, docUrl) {
-  const pdfResponse = await getPDFLink();
+async function compileNoteData(title, docId, docUrl) {
+  const pdfResponse = await getPDFLink(docId);
   const pdfSource = pdfResponse.result.exportLinks['application/pdf'];
   const payload = {
     title: title,
@@ -166,7 +167,7 @@ async function compileNoteData(title, docUrl) {
 /** Retrieves PDF export link of Google Doc */
 function getPDFLink(docId) {
   return gapi.client.drive.files.get({
-    fileId: '1at_wZV-4ul2pV_VCkFu2oG9t0rhrzfEguZpt2rRzTs0',
+    fileId: docId,
     fields: 'exportLinks'
   });
 }

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -140,9 +140,11 @@ function generateNote() {
   }).then(response => {
     const docId = response.result.id;
     const gNoteUrl = GOOGLE_DOC_URL + docId;
-    compileNoteData(docName, docId, gNoteUrl);
-    loadingIcon.style.display = 'none';
-    chrome.tabs.create({ url: gNoteUrl });
+    compileNoteData(docName, docId, gNoteUrl)
+      .then(() => {
+        loadingIcon.style.display = 'none';
+        chrome.tabs.create({ url: gNoteUrl });
+      });
   }).catch(error => {
     loadingIcon.style.display = 'none';
     console.log('Error:', error);
@@ -151,17 +153,19 @@ function generateNote() {
 
 /** Puts together the URL search params for posting the note */
 async function compileNoteData(title, docId, docUrl) {
-  const pdfResponse = await getPDFLink(docId);
-  const pdfSource = pdfResponse.result.exportLinks['application/pdf'];
-  const payload = {
-    title: title,
-    school: 'Unaffiliated',
-    course: 'Unaffiliated',
-    sourceUrl: docUrl,
-    pdfSource: pdfSource
-  }
-  const noteData = new URLSearchParams(payload);
-  postNoteToDatabase(noteData);
+  getPDFLink(docId)
+    .then(response => {
+      const pdfSource = response.result.exportLinks['application/pdf'];
+      const payload = {
+        title: title,
+        school: 'Unaffiliated',
+        course: 'Unaffiliated',
+        sourceUrl: docUrl,
+        pdfSource: pdfSource
+      }
+      const noteData = new URLSearchParams(payload);
+      postNoteToDatabase(noteData);
+    })
 }
 
 /** Retrieves PDF export link of Google Doc */

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -124,8 +124,7 @@ function getDate() {
  */
 function setLoadingIcon(show) {
   const loadingIcon = document.getElementById('loading');
-  if(show) loadingIcon.style.display = 'flex';
-  else loadingIcon.style.display = 'none';
+  loadingIcon.style.display = (show ? 'flex' : 'none');
 }
 
 /**
@@ -199,7 +198,7 @@ function updateGNoteTemplate(docId, docUrl) {
     },
   };
   gapi.client.docs.documents.batchUpdate(updateObject)
-    .then(addGlobalPermissions(docId))
+    .then(() => addGlobalPermissions(docId))
     .then(() => {
       setLoadingIcon(false);
       chrome.tabs.create({ url: docUrl });

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -1,0 +1,130 @@
+package com.google.starfish.servlets;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;  
+import javax.servlet.http.Cookie;  
+import com.google.starfish.services.LabelService;
+import com.google.starfish.services.MiscNoteLabelService;
+import javax.sql.DataSource;
+import java.sql.Connection;  
+import java.sql.SQLException;  
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Date;
+import java.util.Calendar;
+
+/** Servlet to handle note uploading and adding associated labels to the database */
+@WebServlet("/upload-gnote")
+public class UploadGNoteServlet extends HttpServlet {
+
+  private final String COOKIE_NAME = "SFCookie";
+  private LabelService labelService = new LabelService();
+  
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    if(!validateUser(request)) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    HttpSession activeSession = request.getSession(false);
+    String userId = (String) activeSession.getAttribute("user_id");
+
+    String title = request.getParameter("title");
+    String school = request.getParameter("school").toLowerCase();
+    String course = request.getParameter("course").toLowerCase();
+    // String[] miscLabels = request.getParameterValues("miscLabels");
+    String sourceUrl = request.getParameter("sourceUrl");
+    String pdfSource = request.getParameter("pdfSource");
+
+    DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
+
+    // Insert all labels before inserting note due to foreign key constraint
+    labelService.insertSchoolLabel(pool, school);
+    labelService.insertCourseLabel(pool, course);
+    // for (String miscLabel : miscLabels) {
+    //   labelService.insertMiscLabel(pool, miscLabel.toLowerCase());
+    // }
+    
+    try (Connection conn = pool.getConnection()) {
+      String stmt =
+          "INSERT INTO notes ( "
+              + "author_id,"
+              + "school,"
+              + "course,"
+              + "title,"
+              + "source_url,"
+              + "pdf_source,"
+              + "date_created,"
+              + "num_downloads ) "
+        + "VALUES ( "
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "?,"
+              + "? ); ";
+
+      try (PreparedStatement noteStmt = conn.prepareStatement(stmt, new String[] {"id"})) {
+        noteStmt.setString(1, userId);
+        noteStmt.setString(2, school);
+        noteStmt.setString(3, course);
+        noteStmt.setString(4, title);
+        noteStmt.setString(5, sourceUrl);
+        noteStmt.setString(6, pdfSource);
+        noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
+        noteStmt.setLong(8, 0); // num_downloads
+        int rowsAffected = noteStmt.executeUpdate();
+        if (rowsAffected == 1) {
+          long noteId = 0;
+          ResultSet rs = noteStmt.getGeneratedKeys();
+          if (rs.next()) {
+            noteId = rs.getLong(1);
+            // Associate misc labels to the newly added note
+            for (String miscLabel : miscLabels) {
+              miscNoteLabelService.insertMiscNoteLabel(pool, noteId, miscLabel);
+            }
+          } 
+        }
+      }
+    } catch (SQLException ex) {
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.getWriter().println("INTERNAL SERVER ERROR: " + ex);
+    }    
+  }
+
+  /**
+   * Validates the user using the request's session and cookies. If there is a
+   * valid user logged in, returns true. Otherwise, returns false.
+   **/
+  private boolean validateUser(HttpServletRequest req) {
+    Cookie[] cookies = req.getCookies();
+    String sessionId = null;
+    for (Cookie cookie : cookies) {
+      if (COOKIE_NAME.equals(cookie.getName())) {
+        sessionId = cookie.getValue();
+        break;
+      }
+    }
+
+    // If there was no cookie passed, then auth has failed and user is not logged in
+    if(sessionId == null) {
+      return false;
+    }
+
+    HttpSession activeSession = req.getSession(false);
+    if (activeSession == null || activeSession.getAttribute("user_id") == null) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -46,11 +46,7 @@ public class UploadGNoteServlet extends HttpServlet {
     DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
 
     // Insert all labels before inserting note due to foreign key constraint
-    labelService.insertSchoolLabel(pool, school);
-    labelService.insertCourseLabel(pool, course);
-    // for (String miscLabel : miscLabels) {
-    //   labelService.insertMiscLabel(pool, miscLabel.toLowerCase());
-    // }
+    addLabels(pool, school, course);
     
     try (Connection conn = pool.getConnection()) {
       String stmt =
@@ -71,7 +67,7 @@ public class UploadGNoteServlet extends HttpServlet {
               + "?,"
               + "?,"
               + "?,"
-              + "? ); ";
+              + "0 ); ";
 
       try (PreparedStatement noteStmt = conn.prepareStatement(stmt, new String[] {"id"})) {
         noteStmt.setString(1, userId);
@@ -81,13 +77,18 @@ public class UploadGNoteServlet extends HttpServlet {
         noteStmt.setString(5, sourceUrl);
         noteStmt.setString(6, pdfSource);
         noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
-        noteStmt.setLong(8, 0); // num_downloads
         noteStmt.executeUpdate();
       }
     } catch (SQLException ex) {
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       response.getWriter().println("INTERNAL SERVER ERROR: " + ex);
     }    
+  }
+
+  /** Inserts a school and course label to the database */
+  private void addLabels(DataSource pool, String school, String course) {
+    labelService.insertSchoolLabel(pool, school);
+    labelService.insertCourseLabel(pool, course);
   }
 
   /**

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -43,6 +43,11 @@ public class UploadGNoteServlet extends HttpServlet {
     // String[] miscLabels = request.getParameterValues("miscLabels");
     String sourceUrl = request.getParameter("sourceUrl");
     String pdfSource = request.getParameter("pdfSource");
+    System.out.println(title);
+    System.out.println(school);
+    System.out.println(course);
+    System.out.println(sourceUrl);
+    System.out.println(pdfSource);
 
     DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
 
@@ -87,13 +92,13 @@ public class UploadGNoteServlet extends HttpServlet {
         if (rowsAffected == 1) {
           long noteId = 0;
           ResultSet rs = noteStmt.getGeneratedKeys();
-          if (rs.next()) {
-            noteId = rs.getLong(1);
-            // Associate misc labels to the newly added note
-            for (String miscLabel : miscLabels) {
-              miscNoteLabelService.insertMiscNoteLabel(pool, noteId, miscLabel);
-            }
-          } 
+          // if (rs.next()) {
+          //   noteId = rs.getLong(1);
+          //   // Associate misc labels to the newly added note
+          //   for (String miscLabel : miscLabels) {
+          //     miscNoteLabelService.insertMiscNoteLabel(pool, noteId, miscLabel);
+          //   }
+          // } 
         }
       }
     } catch (SQLException ex) {

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -20,7 +20,10 @@ import java.sql.ResultSet;
 import java.sql.Date;
 import java.util.Calendar;
 
-/** Servlet to handle note uploading and adding associated labels to the database */
+/**
+ * Servlet to handle note uploading and adding associated labels to the database
+ * for gnotes from the chrome extension
+ */
 @WebServlet("/upload-gnote")
 public class UploadGNoteServlet extends HttpServlet {
 

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -40,14 +40,8 @@ public class UploadGNoteServlet extends HttpServlet {
     String title = request.getParameter("title");
     String school = request.getParameter("school").toLowerCase();
     String course = request.getParameter("course").toLowerCase();
-    // String[] miscLabels = request.getParameterValues("miscLabels");
     String sourceUrl = request.getParameter("sourceUrl");
     String pdfSource = request.getParameter("pdfSource");
-    System.out.println(title);
-    System.out.println(school);
-    System.out.println(course);
-    System.out.println(sourceUrl);
-    System.out.println(pdfSource);
 
     DataSource pool = (DataSource) request.getServletContext().getAttribute("my-pool");
 
@@ -88,18 +82,7 @@ public class UploadGNoteServlet extends HttpServlet {
         noteStmt.setString(6, pdfSource);
         noteStmt.setDate(7, new Date(Calendar.getInstance().getTimeInMillis()));
         noteStmt.setLong(8, 0); // num_downloads
-        int rowsAffected = noteStmt.executeUpdate();
-        if (rowsAffected == 1) {
-          long noteId = 0;
-          ResultSet rs = noteStmt.getGeneratedKeys();
-          // if (rs.next()) {
-          //   noteId = rs.getLong(1);
-          //   // Associate misc labels to the newly added note
-          //   for (String miscLabel : miscLabels) {
-          //     miscNoteLabelService.insertMiscNoteLabel(pool, noteId, miscLabel);
-          //   }
-          // } 
-        }
+        noteStmt.executeUpdate();
       }
     } catch (SQLException ex) {
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
+++ b/src/main/java/com/google/starfish/servlets/UploadGNoteServlet.java
@@ -72,7 +72,7 @@ public class UploadGNoteServlet extends HttpServlet {
               + "?,"
               + "0 ); ";
 
-      try (PreparedStatement noteStmt = conn.prepareStatement(stmt, new String[] {"id"})) {
+      try (PreparedStatement noteStmt = conn.prepareStatement(stmt)) {
         noteStmt.setString(1, userId);
         noteStmt.setString(2, school);
         noteStmt.setString(3, course);


### PR DESCRIPTION
## Popup 
- Added inputs for the school and course. These will be automatically set to 'Unaffiliated' if the user does not enter anything.
- The Open Browser button now works - it will open the Starfish webapp in a new tab (however see TODO at bottom)
![updated-popup](https://user-images.githubusercontent.com/39059181/88226912-ceec8d00-cc3a-11ea-98ac-43f2a003fc12.png)

## User Authentication 
- Once the chrome extension retrieves the OAuth tokens, it makes a request to the `user-registration` servlet with the `idToken` param. 
- When the user logs out, the chrome extension will revoke the `accessToken` and make a request to the `user-logout` servlet which will remove the cookies that were set when the user was registered. 

## Posting a Note
- The `UploadGNoteServlet` handles posting the note to the database.
- After the Google Doc is created, the PDF export link is retrieved and then the title, school, course, pdfSource, and sourceUrl (which is the link to the Google Doc) will be sent as parameters to the `upload-gnote` servlet.
- After the note is added to the database, the chrome extension will send a batch update request to replace all the "[DATE]" fields in the template with the current date.
- After the batch update request, the chrome extension will send another request to create global permissions. This means that anyone with the link to the Google Doc can view it.
- Once the request is completed, the Google Doc will open in a new tab

TODO: One the webapp is deployed, `WEBAPP_URL` will need to be updated. It is currently set to my local development URL.
